### PR TITLE
nixify retrocube to compile and run via both legacy Nix and Nix Flakes

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,35 @@
+# To run this on nix/nixos, just run `nix-build` in the directory containing this file
+# and then run any executable in the result/bin directory,
+# e.g. `./result/bin/cube`
+# Or, if there is a corresponding flake.nix file and you have "flakes" enabled,
+# you can just run "nix run" and it will run the default executable ("cube").
+
+{ pkgs ? import <nixpkgs> {}}:
+with pkgs;
+# fastStdenv.mkDerivation for optimization/faster running times (8-12%) BUT... nondeterministic builds :(
+# Otherwise just use stdenv.mkDerivation
+fastStdenv.mkDerivation {
+  name = "retrocube";
+  src = ./.;
+  
+  enableParallelBuilding = true;
+
+  # any dependencies/build tools needed at compilation/build time
+  nativeBuildInputs = [ pkg-config ncurses gcc ];
+
+  # any dependencies needed at runtime
+  # (why is it not called "runtimeInputs"? and the build time inputs just called "buildInputs"?)
+  buildInputs = [ ];
+
+  # the bash shell steps to build it
+  buildPhase = ''
+    make all
+  '';
+
+  # for a generic copy to the nix store of all compiled executables:
+  # cp $(find * -maxdepth 1 -executable -type f) $out/bin/
+  installPhase = ''
+    mkdir -p $out/bin
+    cp $(find * -maxdepth 1 -executable -type f) $out/bin/
+  '';
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,41 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1674236650,
+        "narHash": "sha256-B4GKL1YdJnII6DQNNJ4wDW1ySJVx2suB1h/v4Ql8J0Q=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "cfb43ad7b941d9c3606fb35d91228da7ebddbfc5",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,26 @@
+# If you run with Nix and you have "flakes" enabled,
+# you can just run "nix run" and it will run the default executable here ("cube").
+# Also see the note(s) at the top of default.nix.
+{
+  inputs = {
+    # nixpkgs.url = github:NixOS/nixpkgs/nixos-21.11;
+    nixpkgs.url = "nixpkgs";
+    flake-utils.url = github:numtide/flake-utils;
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      rec {
+        packages.default = (import ./default.nix)
+          { pkgs = nixpkgs.legacyPackages.${system}; };
+
+        apps = rec {
+          default = retrocube;
+          retrocube = {
+            type = "app";
+            program = "${self.packages.${system}.default}/bin/cube";
+          };
+        };
+      }
+    );
+}


### PR DESCRIPTION
Hi there,

I liked your project (saw it on Reddit) and since I'm trying to learn Nix (and how to bring "legacy" C-compiler projects into it), and your project seemed pretty simple to use as a self-tutorial, I "nixified" your project for you!

The pluses here are numerous:

1) Someone with Nix installed (and flakes enabled) could theoretically run your project directly (without installing anything!) with a single command: `nix run github:pmarreck/retrocube` (or if you accept this pull request, `nix run github:leonmavr/retrocube`).

2) The build is (kinda) guaranteed to work. Forever. Kinda. ;) (Let's just say it's massively more deterministically probable that it will build in the future using the Nix mechanism than pretty much what any other tool out there can claim.) So I've kind of given your repo... "eternal life"? ;)

3) You can potentially use cachix (or any other Nix build cache) to cache the build output, making it so folks don't even have to run the build. See https://nixos.wiki/wiki/Flakes and search for "cachix".

4) Since I did 99% of the work, it's almost a no-op to now put this repo on nixpkgs, if you wish: https://search.nixos.org/packages (Did I mention that this is now more or less guaranteed to run correctly, forever? Assuming I locked down the correct inputs. Wondering if I/we have to account somehow for possible breaking changes to terminal emulation in the future.)

Anyway, I learned stuff, hopefully you will learn stuff, go play with it, everybody wins!

Yours in retro (but also eternal) nerdvana,

-Peter Marreck