### PR TITLE
Add -ltinfo to Makefile address make failed on Gentoo.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ EXEC = cube
 SRC_DIR = src
 INC_DIR = include
 CFLAGS = -Wall -Wno-maybe-uninitialized -I$(INC_DIR) -O3 -std=gnu99
-LDFLAGS = -lncurses -lm
+LDFLAGS = -lncurses -ltinfo -lm
 SOURCES = $(wildcard $(SRC_DIR)/*.c) \
 	main.c
 OBJECTS = $(SOURCES:%.c=%.o)


### PR DESCRIPTION
I'm not sure weather this change will affect other distro, if you tested and this commit will cause retrocube failed to builed on other distro, I will discard this pull request.

Thank you for create this awesome project, Zou. 